### PR TITLE
Minor UI improvements

### DIFF
--- a/Hera.xcodeproj/project.pbxproj
+++ b/Hera.xcodeproj/project.pbxproj
@@ -734,6 +734,7 @@
 				DEVELOPMENT_TEAM = 4TPXP6N79S;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Hera/Info.plist;
+				INFOPLIST_KEY_NSFaceIDUsageDescription = "The app uses Face ID to allow users to authenticate themselves";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -745,7 +746,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.andreaslordos.Hera;
+				PRODUCT_BUNDLE_IDENTIFIER = com.andreaslordos.Heraa;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Hera/ViewControllers/Main Flow/Cycle/Hera-Bridging-Header.h";
@@ -767,6 +768,7 @@
 				DEVELOPMENT_TEAM = 3P2W72R536;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Hera/Info.plist;
+				INFOPLIST_KEY_NSFaceIDUsageDescription = "The app uses Face ID to allow users to authenticate themselves";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;

--- a/Hera.xcodeproj/project.pbxproj
+++ b/Hera.xcodeproj/project.pbxproj
@@ -731,7 +731,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4TPXP6N79S;
+				DEVELOPMENT_TEAM = 3P2W72R536;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Hera/Info.plist;
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "The app uses Face ID to allow users to authenticate themselves";
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.andreaslordos.Heraa;
+				PRODUCT_BUNDLE_IDENTIFIER = com.andreaslordos.Hera;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Hera/ViewControllers/Main Flow/Cycle/Hera-Bridging-Header.h";

--- a/Hera/Base.lproj/Main.storyboard
+++ b/Hera/Base.lproj/Main.storyboard
@@ -272,7 +272,7 @@
                                             <action selector="didTapPeriodButton:" destination="wEd-Ya-CIA" eventType="touchUpInside" id="CHQ-oY-FSg"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ceO-Sy-Qva" userLabel="emotionButton">
+                                    <button opaque="NO" alpha="0.25" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ceO-Sy-Qva" userLabel="emotionButton">
                                         <rect key="frame" x="124.66666666666666" y="0.0" width="104.66666666666666" height="100"/>
                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>
@@ -284,7 +284,7 @@
                                             <action selector="didTapEmotionButton:" destination="wEd-Ya-CIA" eventType="touchUpInside" id="Bvq-rF-q7y"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z9H-3v-jjv" userLabel="painButton">
+                                    <button opaque="NO" alpha="0.25" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z9H-3v-jjv" userLabel="painButton">
                                         <rect key="frame" x="249.33333333333329" y="0.0" width="104.66666666666666" height="100"/>
                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>

--- a/Hera/Base.lproj/Main.storyboard
+++ b/Hera/Base.lproj/Main.storyboard
@@ -273,7 +273,7 @@
                                         <rect key="frame" x="124.66666666666666" y="0.0" width="104.66666666666666" height="100"/>
                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="filled" image="smiley" catalog="system">
+                                        <buttonConfiguration key="configuration" style="filled" image="face.smiling" catalog="system">
                                             <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <color key="baseBackgroundColor" systemColor="systemOrangeColor"/>
                                         </buttonConfiguration>
@@ -593,7 +593,7 @@
                             <constraint firstItem="vx1-by-Wdh" firstAttribute="leading" secondItem="j6p-6C-E8D" secondAttribute="leading" id="tQd-Ar-fj2"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Cycle" image="leaf.arrow.circlepath" catalog="system" selectedImage="leaf.arrow.circlepath" id="rE6-fi-yIu"/>
+                    <tabBarItem key="tabBarItem" title="Cycle" image="leaf.arrow.circlepath" catalog="system" selectedImage="leaf.arrow.triangle.circlepath" id="rE6-fi-yIu"/>
                     <connections>
                         <outlet property="bleedingLabel" destination="I9M-rp-aNF" id="4p7-fu-56x"/>
                         <outlet property="dayCounter" destination="sun-jN-IA4" id="tP7-h1-5tJ"/>
@@ -971,15 +971,16 @@
         <image name="circle.hexagonpath" catalog="system" width="128" height="112"/>
         <image name="cross.circle" catalog="system" width="128" height="121"/>
         <image name="drop" catalog="system" width="101" height="128"/>
+        <image name="face.smiling" catalog="system" width="128" height="121"/>
         <image name="faceid" catalog="system" width="128" height="115"/>
         <image name="gearshape" catalog="system" width="128" height="121"/>
         <image name="hera_appicon" width="352" height="354"/>
         <image name="leaf.arrow.circlepath" catalog="system" width="121" height="128"/>
+        <image name="leaf.arrow.triangle.circlepath" catalog="system" width="121" height="128"/>
         <image name="lines.measurement.horizontal" catalog="system" width="128" height="92"/>
         <image name="meditation" width="512" height="512"/>
         <image name="notification" width="512" height="512"/>
         <image name="plus" catalog="system" width="128" height="113"/>
-        <image name="smiley" catalog="system" width="128" height="121"/>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>

--- a/Hera/Base.lproj/Main.storyboard
+++ b/Hera/Base.lproj/Main.storyboard
@@ -228,7 +228,14 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                                 <color key="barTintColor" systemColor="systemBackgroundColor"/>
                                 <items>
-                                    <navigationItem title="Today" id="LTh-bh-28L"/>
+                                    <navigationItem title="Today" id="LTh-bh-28L">
+                                        <barButtonItem key="leftBarButtonItem" title="Item" id="HrG-J5-gBb">
+                                            <imageReference key="image" image="calendar" catalog="system" symbolScale="default"/>
+                                            <connections>
+                                                <action selector="didTapCalendar:" destination="hKJ-Lt-ti1" id="aQE-Dl-09J"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
                                 </items>
                             </navigationBar>
                         </subviews>

--- a/Hera/Base.lproj/Main.storyboard
+++ b/Hera/Base.lproj/Main.storyboard
@@ -241,6 +241,9 @@
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Calendar" image="calendar" catalog="system" selectedImage="calendar" id="mXx-fY-FeY"/>
+                    <connections>
+                        <outlet property="titleBar" destination="LTh-bh-28L" id="zfF-mk-3oK"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="EOj-0J-S4m" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -441,7 +444,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                                 <color key="barTintColor" systemColor="systemBackgroundColor"/>
                                 <items>
-                                    <navigationItem title="Logging" id="gTG-v4-O42">
+                                    <navigationItem title="Tracking" id="gTG-v4-O42">
                                         <barButtonItem key="rightBarButtonItem" style="plain" id="zKB-v2-Kp2">
                                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="7P4-L3-N7U">
                                                 <rect key="frame" x="339.33333333333331" y="5" width="54.666666666666686" height="34.333333333333336"/>

--- a/Hera/Info.plist
+++ b/Hera/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>UIApplicationExitsOnSuspend</key>
 	<true/>
-	<key>NSFaceIDUsageDescription</key>
-	<string>The app uses Face ID to allow users to authenticate themselves</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Hera/ViewControllers/LoginScreenViewController.m
+++ b/Hera/ViewControllers/LoginScreenViewController.m
@@ -19,6 +19,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view.
+    [self didTapUnlock:self];
 }
 
 /*

--- a/Hera/ViewControllers/Main Flow/Calendar/CalendarViewController.m
+++ b/Hera/ViewControllers/Main Flow/Calendar/CalendarViewController.m
@@ -24,7 +24,7 @@
 - (void)setAppearanceCalendar {
     
     // create calendar object
-    FSCalendar *calendar = [[FSCalendar alloc] initWithFrame:CGRectMake(0, 40, self.view.frame.size.width - 20, self.view.frame.size.height - 80)];
+    FSCalendar *calendar = [[FSCalendar alloc] initWithFrame:CGRectMake(0, 80, self.view.frame.size.width - 20, self.view.frame.size.height - 80)];
     
     calendar.dataSource = self;
     calendar.delegate = self;

--- a/Hera/ViewControllers/Main Flow/Calendar/CalendarViewController.m
+++ b/Hera/ViewControllers/Main Flow/Calendar/CalendarViewController.m
@@ -10,6 +10,7 @@
 @interface CalendarViewController () <FSCalendarDelegate, FSCalendarDelegateAppearance, FSCalendarDataSource>
 
 @property (strong, atomic) NSDate *today;
+@property (weak, nonatomic) IBOutlet UINavigationItem *titleBar;
 
 @end
 
@@ -116,5 +117,49 @@
     NSDateComponents *offsetComponents = [[NSDateComponents alloc] init];
     [offsetComponents setYear:-1];
     return [gregorian dateByAddingComponents:offsetComponents toDate:_today options:0];
+}
+
+- (void)calendar:(FSCalendar *)calendar didSelectDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)monthPosition {
+    NSCalendar *diff_calendar = [NSCalendar currentCalendar];
+    //declare your unitFlags
+    int unitFlags = NSCalendarUnitWeekOfYear | NSCalendarUnitDay | NSCalendarUnitMonth;
+
+    NSDateComponents *dateComponents = [diff_calendar components:unitFlags fromDate:date  toDate:_today options:0];
+
+    long monthsInBetween = [dateComponents month];
+    long weeksInBetween = [dateComponents weekOfYear];
+    long daysInBetween = [dateComponents day];
+    
+    NSString *descriptor = @"";
+    long length = 0;
+    if (monthsInBetween >= 12) {
+        descriptor = @"year";
+        length = 1;
+    }
+    else if (monthsInBetween > 0) {
+        descriptor = @"month";
+        length = monthsInBetween;
+    }
+    else if (weeksInBetween > 0) {
+        descriptor = @"week";
+        length = weeksInBetween;
+    }
+    else if (daysInBetween > 0) {
+        descriptor = @"day";
+        length = daysInBetween;
+    }
+    else {
+        [_titleBar setTitle:@"Today"];
+        return;
+    }
+    
+    if (length > 1) {
+        descriptor = [descriptor stringByAppendingString:@"s"];
+    }
+    descriptor = [[NSString stringWithFormat:@"%lu ", length] stringByAppendingString:descriptor];
+    
+    NSString *title = [descriptor stringByAppendingString:@" ago"];
+    
+    [_titleBar setTitle:title];
 }
 @end

--- a/Hera/ViewControllers/Main Flow/Calendar/CalendarViewController.m
+++ b/Hera/ViewControllers/Main Flow/Calendar/CalendarViewController.m
@@ -11,6 +11,7 @@
 
 @property (strong, atomic) NSDate *today;
 @property (weak, nonatomic) IBOutlet UINavigationItem *titleBar;
+- (IBAction)didTapCalendar:(id)sender;
 
 @end
 
@@ -20,6 +21,10 @@
     [super viewDidLoad];
     _today = [[NSDate alloc] init];
     [self setAppearanceCalendar];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [_calendar setCurrentPage:[NSDate date] animated:NO];
 }
 
 - (void)setAppearanceCalendar {
@@ -161,5 +166,10 @@
     NSString *title = [descriptor stringByAppendingString:@" ago"];
     
     [_titleBar setTitle:title];
+}
+
+- (IBAction)didTapCalendar:(id)sender {
+    NSLog(@"YES");
+    [_calendar setCurrentPage:[NSDate date] animated:YES];
 }
 @end

--- a/Hera/ViewControllers/Main Flow/Logging/LoggingViewController.m
+++ b/Hera/ViewControllers/Main Flow/Logging/LoggingViewController.m
@@ -210,6 +210,7 @@
     _option4.backgroundColor = [UIColor colorWithCGColor:_option4.layer.borderColor];
     _option4.tintColor = [UIColor whiteColor];
     _lastOptionSelected = @"4";
+    _option4.alpha = 1.;
 }
 
 - (IBAction)didTapOption3:(id)sender {
@@ -217,6 +218,7 @@
     _option3.backgroundColor = [UIColor colorWithCGColor:_option3.layer.borderColor];
     _option3.tintColor = [UIColor whiteColor];
     _lastOptionSelected = @"3";
+    _option3.alpha = 1.;
 }
 
 - (IBAction)didTapOption2:(id)sender {
@@ -224,6 +226,7 @@
     _option2.backgroundColor = [UIColor colorWithCGColor:_option2.layer.borderColor];
     _option2.tintColor = [UIColor whiteColor];
     _lastOptionSelected = @"2";
+    _option2.alpha = 1.;
 }
 
 - (IBAction)didTapOption1:(id)sender {
@@ -231,6 +234,7 @@
     _option1.backgroundColor = [UIColor colorWithCGColor:_option1.layer.borderColor];
     _option1.tintColor = [UIColor whiteColor];
     _lastOptionSelected = @"1";
+    _option1.alpha = 1.;
 }
 
 - (IBAction)didTapEmotionButton:(id)sender {
@@ -239,6 +243,7 @@
     [self setButtonLabels:[NSArray arrayWithObjects:@"Happy", @"Sensitive", @"Sad", @"PMS", nil]];
     [self resetButtons];
     _lastTypeSelected = @"Emotion";
+    [self setButtonAlphas:_emotionButton];
 }
 
 - (IBAction)didTapPainButton:(id)sender {
@@ -247,6 +252,7 @@
     [self setButtonLabels:[NSArray arrayWithObjects:@"Cramps", @"Headache", @"Ovulation", @"Tender Breasts", nil]];
     [self resetButtons];
     _lastTypeSelected = @"Pain";
+    [self setButtonAlphas:_painButton];
 }
 
 - (IBAction)didTapPeriodButton:(id)sender {
@@ -255,5 +261,14 @@
     [self setButtonLabels:[NSArray arrayWithObjects:@"Light", @"Moderate", @"Heavy", @"Spotting", nil]];
     [self resetButtons];
     _lastTypeSelected = @"Period";
+    [self setButtonAlphas:_periodButton];
+    
+}
+
+- (void)setButtonAlphas:(UIButton*)button {
+    _painButton.alpha = .25;
+    _periodButton.alpha = .25;
+    _emotionButton.alpha = .25;
+    button.alpha = 1.;
 }
 @end


### PR DESCRIPTION
UI improvements on calendar
- Removed gap between Calendar header and top of screen
- Title on calendar header is dynamic, depending on the cell you select. If the current cell selected is today's cell, the title of the header will be "Today". If you select a cell from 15 days ago, the title of the header will be "2 weeks ago" etc.
- Added a button in the calendar header to reset the view to current day

UX improvements
- No need to press "unlock hera" button on startup, face id starts up automatically

UI improvements in logging
- Makes clear which button is selected by slightly fading out the non-selected buttons