### PR TITLE
[Display Module] Add custom cells showing probability of period/ovulation

### DIFF
--- a/Hera.xcodeproj/project.pbxproj
+++ b/Hera.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		BF7863CF28887CA600417C36 /* CalendarViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7863CE28887CA600417C36 /* CalendarViewController.m */; };
 		BF7863D228887D8300417C36 /* cc_calendar.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7863D128887D8300417C36 /* cc_calendar.m */; };
 		BF7863DA2889B6A100417C36 /* CycleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7863D92889B6A100417C36 /* CycleViewController.swift */; };
+		BF7863DD288B59DD00417C36 /* DIYCalendarCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7863DC288B59DD00417C36 /* DIYCalendarCell.m */; };
 		BF9054A7287E2F5A0061001C /* TermsAndConditionsVC.m in Sources */ = {isa = PBXBuildFile; fileRef = BF9054A6287E2F5A0061001C /* TermsAndConditionsVC.m */; };
 		BFBD3D5228820D1C008743B8 /* StartupViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BFBD3D5128820D1C008743B8 /* StartupViewController.m */; };
 		BFBD3D5B2885CD40008743B8 /* LoginScreenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BFBD3D5A2885CD40008743B8 /* LoginScreenViewController.m */; };
@@ -74,6 +75,8 @@
 		BF7863D128887D8300417C36 /* cc_calendar.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = cc_calendar.m; sourceTree = "<group>"; };
 		BF7863D82889B6A100417C36 /* Hera-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Hera-Bridging-Header.h"; sourceTree = "<group>"; };
 		BF7863D92889B6A100417C36 /* CycleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleViewController.swift; sourceTree = "<group>"; };
+		BF7863DB288B59DD00417C36 /* DIYCalendarCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DIYCalendarCell.h; sourceTree = "<group>"; };
+		BF7863DC288B59DD00417C36 /* DIYCalendarCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DIYCalendarCell.m; sourceTree = "<group>"; };
 		BF9054A5287E2F5A0061001C /* TermsAndConditionsVC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TermsAndConditionsVC.h; sourceTree = "<group>"; };
 		BF9054A6287E2F5A0061001C /* TermsAndConditionsVC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TermsAndConditionsVC.m; sourceTree = "<group>"; };
 		BFBD3D5028820D1C008743B8 /* StartupViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StartupViewController.h; sourceTree = "<group>"; };
@@ -188,6 +191,8 @@
 				BF7863CE28887CA600417C36 /* CalendarViewController.m */,
 				BF7863D028887D8300417C36 /* cc_calendar.h */,
 				BF7863D128887D8300417C36 /* cc_calendar.m */,
+				BF7863DB288B59DD00417C36 /* DIYCalendarCell.h */,
+				BF7863DC288B59DD00417C36 /* DIYCalendarCell.m */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -547,6 +552,7 @@
 				BFD11BE0287E74140006E93E /* PeriodLengthViewController.m in Sources */,
 				BFD11BE6287F9B700006E93E /* Utilities.m in Sources */,
 				BFBD3D5228820D1C008743B8 /* StartupViewController.m in Sources */,
+				BF7863DD288B59DD00417C36 /* DIYCalendarCell.m in Sources */,
 				BF078DBC287E511900608897 /* LastPeriodViewController.m in Sources */,
 				BF7863DA2889B6A100417C36 /* CycleViewController.swift in Sources */,
 				BFD3185A287E2279003E85F3 /* Hera.xcdatamodeld in Sources */,

--- a/Hera.xcodeproj/project.pbxproj
+++ b/Hera.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		BF7863D228887D8300417C36 /* cc_calendar.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7863D128887D8300417C36 /* cc_calendar.m */; };
 		BF7863DA2889B6A100417C36 /* CycleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7863D92889B6A100417C36 /* CycleViewController.swift */; };
 		BF7863DD288B59DD00417C36 /* DIYCalendarCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7863DC288B59DD00417C36 /* DIYCalendarCell.m */; };
+		BF7863E0288F291C00417C36 /* get_predictions.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7863DF288F291C00417C36 /* get_predictions.m */; };
 		BF9054A7287E2F5A0061001C /* TermsAndConditionsVC.m in Sources */ = {isa = PBXBuildFile; fileRef = BF9054A6287E2F5A0061001C /* TermsAndConditionsVC.m */; };
 		BFBD3D5228820D1C008743B8 /* StartupViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BFBD3D5128820D1C008743B8 /* StartupViewController.m */; };
 		BFBD3D5B2885CD40008743B8 /* LoginScreenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BFBD3D5A2885CD40008743B8 /* LoginScreenViewController.m */; };
@@ -77,6 +78,8 @@
 		BF7863D92889B6A100417C36 /* CycleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleViewController.swift; sourceTree = "<group>"; };
 		BF7863DB288B59DD00417C36 /* DIYCalendarCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DIYCalendarCell.h; sourceTree = "<group>"; };
 		BF7863DC288B59DD00417C36 /* DIYCalendarCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DIYCalendarCell.m; sourceTree = "<group>"; };
+		BF7863DE288F291C00417C36 /* get_predictions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = get_predictions.h; sourceTree = "<group>"; };
+		BF7863DF288F291C00417C36 /* get_predictions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = get_predictions.m; sourceTree = "<group>"; };
 		BF9054A5287E2F5A0061001C /* TermsAndConditionsVC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TermsAndConditionsVC.h; sourceTree = "<group>"; };
 		BF9054A6287E2F5A0061001C /* TermsAndConditionsVC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TermsAndConditionsVC.m; sourceTree = "<group>"; };
 		BFBD3D5028820D1C008743B8 /* StartupViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StartupViewController.h; sourceTree = "<group>"; };
@@ -193,6 +196,8 @@
 				BF7863D128887D8300417C36 /* cc_calendar.m */,
 				BF7863DB288B59DD00417C36 /* DIYCalendarCell.h */,
 				BF7863DC288B59DD00417C36 /* DIYCalendarCell.m */,
+				BF7863DE288F291C00417C36 /* get_predictions.h */,
+				BF7863DF288F291C00417C36 /* get_predictions.m */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -547,6 +552,7 @@
 				BF7863D228887D8300417C36 /* cc_calendar.m in Sources */,
 				BFD31862287E227A003E85F3 /* main.m in Sources */,
 				BF9054A7287E2F5A0061001C /* TermsAndConditionsVC.m in Sources */,
+				BF7863E0288F291C00417C36 /* get_predictions.m in Sources */,
 				BFD31854287E2279003E85F3 /* ViewController.m in Sources */,
 				BFBD3D5B2885CD40008743B8 /* LoginScreenViewController.m in Sources */,
 				BFD11BE0287E74140006E93E /* PeriodLengthViewController.m in Sources */,

--- a/Hera/ViewControllers/Main Flow/Calendar/CalendarViewController.m
+++ b/Hera/ViewControllers/Main Flow/Calendar/CalendarViewController.m
@@ -6,12 +6,16 @@
 //
 
 #import "CalendarViewController.h"
+#import "DIYCalendarCell.h"
 
 @interface CalendarViewController () <FSCalendarDelegate, FSCalendarDelegateAppearance, FSCalendarDataSource>
 
 @property (strong, atomic) NSDate *today;
 @property (weak, nonatomic) IBOutlet UINavigationItem *titleBar;
+@property (strong, nonatomic) NSCalendar *gregorian;
+
 - (IBAction)didTapCalendar:(id)sender;
+- (void)configureCell:(FSCalendarCell *)cell forDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)position;
 
 @end
 
@@ -19,6 +23,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.gregorian = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
     _today = [[NSDate alloc] init];
     [self setAppearanceCalendar];
 }
@@ -51,9 +56,10 @@
     calendar.center = CGPointMake(CGRectGetMidX(self.view.bounds), calendar.center.y); // center calendar
     [calendar selectDate:_today];
     calendar.appearance.headerTitleColor = [UIColor blackColor];
-
     [calendar setPagingEnabled:NO]; // multiple months on the same screen
-    [calendar setPlaceholderType:FSCalendarPlaceholderTypeNone];
+    [calendar setPlaceholderType:FSCalendarPlaceholderTypeNone]; // remove mon
+    
+    [calendar registerClass:[DIYCalendarCell class] forCellReuseIdentifier:@"cell"];
     
     // add calendar to view
     [self.view addSubview:calendar];
@@ -110,18 +116,16 @@
 
 // 6 months forward calendar
 - (NSDate *)maximumDateForCalendar:(FSCalendar *)calendar {
-    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     NSDateComponents *offsetComponents = [[NSDateComponents alloc] init];
     [offsetComponents setMonth:6];
-    return [gregorian dateByAddingComponents:offsetComponents toDate:_today options:0];
+    return [self.gregorian dateByAddingComponents:offsetComponents toDate:_today options:0];
 
 }
 
 - (NSDate *)minimumDateForCalendar:(FSCalendar *)calendar {
-    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     NSDateComponents *offsetComponents = [[NSDateComponents alloc] init];
     [offsetComponents setYear:-1];
-    return [gregorian dateByAddingComponents:offsetComponents toDate:_today options:0];
+    return [self.gregorian dateByAddingComponents:offsetComponents toDate:_today options:0];
 }
 
 - (void)calendar:(FSCalendar *)calendar didSelectDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)monthPosition {
@@ -172,4 +176,58 @@
     NSLog(@"YES");
     [_calendar setCurrentPage:[NSDate date] animated:YES];
 }
+
+- (FSCalendarCell *)calendar:(FSCalendar *)calendar cellForDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)monthPosition
+{
+    DIYCalendarCell *cell = [calendar dequeueReusableCellWithIdentifier:@"cell" forDate:date atMonthPosition:monthPosition];
+    return cell;
+}
+
+- (void)configureCell:(FSCalendarCell *)cell forDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)monthPosition
+{
+    
+    DIYCalendarCell *diyCell = (DIYCalendarCell *)cell;
+    
+    // Custom today circle
+    diyCell.circleImageView.hidden = ![self.gregorian isDateInToday:date];
+    
+    // Configure selection layer
+    if (monthPosition == FSCalendarMonthPositionCurrent) {
+        
+        SelectionType selectionType = SelectionTypeNone;
+        if ([self.calendar.selectedDates containsObject:date]) {
+            NSDate *previousDate = [self.gregorian dateByAddingUnit:NSCalendarUnitDay value:-1 toDate:date options:0];
+            NSDate *nextDate = [self.gregorian dateByAddingUnit:NSCalendarUnitDay value:1 toDate:date options:0];
+            if ([self.calendar.selectedDates containsObject:date]) {
+                if ([self.calendar.selectedDates containsObject:previousDate] && [self.calendar.selectedDates containsObject:nextDate]) {
+                    selectionType = SelectionTypeMiddle;
+                } else if ([self.calendar.selectedDates containsObject:previousDate] && [self.calendar.selectedDates containsObject:date]) {
+                    selectionType = SelectionTypeRightBorder;
+                } else if ([self.calendar.selectedDates containsObject:nextDate]) {
+                    selectionType = SelectionTypeLeftBorder;
+                } else {
+                    selectionType = SelectionTypeSingle;
+                }
+            }
+        } else {
+            selectionType = SelectionTypeNone;
+        }
+        
+        if (selectionType == SelectionTypeNone) {
+            diyCell.selectionLayer.hidden = YES;
+            return;
+        }
+        
+        diyCell.selectionLayer.hidden = NO;
+        diyCell.selectionType = selectionType;
+        
+    } else {
+        
+        diyCell.circleImageView.hidden = YES;
+        diyCell.selectionLayer.hidden = YES;
+        
+    }
+}
+
+
 @end

--- a/Hera/ViewControllers/Main Flow/Calendar/CalendarViewController.m
+++ b/Hera/ViewControllers/Main Flow/Calendar/CalendarViewController.m
@@ -7,12 +7,15 @@
 
 #import "CalendarViewController.h"
 #import "DIYCalendarCell.h"
+#import "get_predictions.h"
 
 @interface CalendarViewController () <FSCalendarDelegate, FSCalendarDelegateAppearance, FSCalendarDataSource>
 
 @property (strong, atomic) NSDate *today;
 @property (weak, nonatomic) IBOutlet UINavigationItem *titleBar;
 @property (strong, nonatomic) NSCalendar *gregorian;
+@property NSMutableDictionary *periodDates;
+@property NSMutableDictionary *ovulationDates;
 
 - (IBAction)didTapCalendar:(id)sender;
 - (void)configureCell:(FSCalendarCell *)cell forDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)position;
@@ -26,10 +29,17 @@
     self.gregorian = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
     _today = [[NSDate alloc] init];
     [self setAppearanceCalendar];
+    get_predictions *predictions = [[get_predictions alloc] init];
+    _periodDates = [predictions getPeriod];
+    _ovulationDates = [predictions getOvulation];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     [_calendar setCurrentPage:[NSDate date] animated:NO];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [self configureVisibleCells];
 }
 
 - (void)setAppearanceCalendar {
@@ -60,7 +70,6 @@
     [calendar setPlaceholderType:FSCalendarPlaceholderTypeNone]; // remove mon
     
     [calendar registerClass:[DIYCalendarCell class] forCellReuseIdentifier:@"cell"];
-    
     // add calendar to view
     [self.view addSubview:calendar];
     [self.view sendSubviewToBack:calendar];
@@ -82,7 +91,8 @@
 
     return [comp1 day]   == [comp2 day] &&
     [comp1 month] == [comp2 month] &&
-    [comp1 year]  == [comp2 year];}
+    [comp1 year]  == [comp2 year];
+}
 
 - (UIColor *)calendar:(FSCalendar *)calendar appearance:(FSCalendarAppearance *)appearance fillDefaultColorForDate:(NSDate *)date {
     if ([self isSameDay:_today otherDay:date]) {
@@ -126,6 +136,16 @@
     NSDateComponents *offsetComponents = [[NSDateComponents alloc] init];
     [offsetComponents setYear:-1];
     return [self.gregorian dateByAddingComponents:offsetComponents toDate:_today options:0];
+}
+
+
+- (void)configureVisibleCells {
+     NSArray *visibleCells = [_calendar visibleCells];
+     for (FSCalendarCell* cell in visibleCells) {
+         NSDate *date = [_calendar dateForCell:cell];
+         FSCalendarMonthPosition position = [_calendar monthPositionForCell:cell];
+        [self configureCell:cell forDate:date atMonthPosition:position];
+    }
 }
 
 - (void)calendar:(FSCalendar *)calendar didSelectDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)monthPosition {
@@ -173,61 +193,39 @@
 }
 
 - (IBAction)didTapCalendar:(id)sender {
-    NSLog(@"YES");
     [_calendar setCurrentPage:[NSDate date] animated:YES];
 }
 
 - (FSCalendarCell *)calendar:(FSCalendar *)calendar cellForDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)monthPosition
 {
     DIYCalendarCell *cell = [calendar dequeueReusableCellWithIdentifier:@"cell" forDate:date atMonthPosition:monthPosition];
+    [self configureCell:cell forDate:date atMonthPosition:monthPosition];
     return cell;
 }
 
-- (void)configureCell:(FSCalendarCell *)cell forDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)monthPosition
-{
-    
-    DIYCalendarCell *diyCell = (DIYCalendarCell *)cell;
-    
-    // Custom today circle
-    diyCell.circleImageView.hidden = ![self.gregorian isDateInToday:date];
-    
-    // Configure selection layer
-    if (monthPosition == FSCalendarMonthPositionCurrent) {
-        
-        SelectionType selectionType = SelectionTypeNone;
-        if ([self.calendar.selectedDates containsObject:date]) {
-            NSDate *previousDate = [self.gregorian dateByAddingUnit:NSCalendarUnitDay value:-1 toDate:date options:0];
-            NSDate *nextDate = [self.gregorian dateByAddingUnit:NSCalendarUnitDay value:1 toDate:date options:0];
-            if ([self.calendar.selectedDates containsObject:date]) {
-                if ([self.calendar.selectedDates containsObject:previousDate] && [self.calendar.selectedDates containsObject:nextDate]) {
-                    selectionType = SelectionTypeMiddle;
-                } else if ([self.calendar.selectedDates containsObject:previousDate] && [self.calendar.selectedDates containsObject:date]) {
-                    selectionType = SelectionTypeRightBorder;
-                } else if ([self.calendar.selectedDates containsObject:nextDate]) {
-                    selectionType = SelectionTypeLeftBorder;
-                } else {
-                    selectionType = SelectionTypeSingle;
-                }
-            }
-        } else {
-            selectionType = SelectionTypeNone;
-        }
-        
-        if (selectionType == SelectionTypeNone) {
-            diyCell.selectionLayer.hidden = YES;
-            return;
-        }
-        
-        diyCell.selectionLayer.hidden = NO;
-        diyCell.selectionType = selectionType;
-        
-    } else {
-        
-        diyCell.circleImageView.hidden = YES;
-        diyCell.selectionLayer.hidden = YES;
-        
-    }
+
+- (NSString*)formatDate:(NSDate *)date {
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd"];
+    return [dateFormatter stringFromDate:date];
 }
 
+- (void)configureCell:(DIYCalendarCell *)diyCell forDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)monthPosition
+{
+    [diyCell setOvulationProbability:0.0];
+    [diyCell setPeriodProbability:0.0];
+    if ([_periodDates objectForKey:[self formatDate:date]]) {
+        [diyCell setPeriodProbability:[[_periodDates objectForKey:[self formatDate:date]] floatValue]];
+    }
+    
+    if ([_ovulationDates objectForKey:[self formatDate:date]]) {
+        [diyCell setOvulationProbability:[[_ovulationDates objectForKey:[self formatDate:date]] floatValue]];
+    }
+    
+//    if ([self isSameDay:_today otherDay:date]) {
+//        NSLog(@"%@", date);
+//        [diyCell setOvulationProbability:0.5];
+//    }
+}
 
 @end

--- a/Hera/ViewControllers/Main Flow/Calendar/DIYCalendarCell.h
+++ b/Hera/ViewControllers/Main Flow/Calendar/DIYCalendarCell.h
@@ -13,9 +13,6 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSUInteger, SelectionType) {
     SelectionTypeNone,
     SelectionTypeSingle,
-    SelectionTypeLeftBorder,
-    SelectionTypeMiddle,
-    SelectionTypeRightBorder
 };
 
 @interface DIYCalendarCell : FSCalendarCell
@@ -25,6 +22,9 @@ typedef NS_ENUM(NSUInteger, SelectionType) {
 @property (weak, nonatomic) CAShapeLayer *selectionLayer;
 
 @property (assign, nonatomic) SelectionType selectionType;
+
+- (void)setPeriodProbability:(CGFloat)probability;
+- (void)setOvulationProbability:(CGFloat)probability;
 
 @end
 

--- a/Hera/ViewControllers/Main Flow/Calendar/DIYCalendarCell.h
+++ b/Hera/ViewControllers/Main Flow/Calendar/DIYCalendarCell.h
@@ -1,0 +1,31 @@
+//
+//  DIYCalendarCell.h
+//  Hera
+//
+//  Created by Andreas Lordos on 7/22/22.
+//
+
+#import <Foundation/Foundation.h>
+#import <FSCalendar/FSCalendar.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSUInteger, SelectionType) {
+    SelectionTypeNone,
+    SelectionTypeSingle,
+    SelectionTypeLeftBorder,
+    SelectionTypeMiddle,
+    SelectionTypeRightBorder
+};
+
+@interface DIYCalendarCell : FSCalendarCell
+
+@property (weak, nonatomic) UIImageView *circleImageView;
+
+@property (weak, nonatomic) CAShapeLayer *selectionLayer;
+
+@property (assign, nonatomic) SelectionType selectionType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Hera/ViewControllers/Main Flow/Calendar/DIYCalendarCell.m
+++ b/Hera/ViewControllers/Main Flow/Calendar/DIYCalendarCell.m
@@ -1,0 +1,84 @@
+//
+//  DIYCalendarCell.m
+//  Hera
+//
+//  Created by Andreas Lordos on 7/22/22.
+//
+
+#import "DIYCalendarCell.h"
+#import "FSCalendarExtensions.h"
+#import "cc_calendar.h"
+
+@implementation DIYCalendarCell
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        UIImageView *circleImageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"circle"]];
+        [self.contentView insertSubview:circleImageView atIndex:0];
+        self.circleImageView = circleImageView;
+        
+        CAShapeLayer *selectionLayer = [[CAShapeLayer alloc] init];
+        selectionLayer.fillColor = [cc_calendar cellSelectedColor].CGColor;
+        selectionLayer.actions = @{@"hidden":[NSNull null]};
+        [self.contentView.layer insertSublayer:selectionLayer below:self.titleLabel.layer];
+        self.selectionLayer = selectionLayer;
+        
+        self.shapeLayer.hidden = YES;
+        self.backgroundView = [[UIView alloc] initWithFrame:self.bounds];
+        self.backgroundView.backgroundColor = [[cc_calendar cellBgColor] colorWithAlphaComponent:1.0];
+        
+    }
+    return self;
+}
+
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    self.backgroundView.frame = CGRectInset(self.bounds, 1, 1);
+    self.circleImageView.frame = self.backgroundView.frame;
+    self.selectionLayer.frame = self.bounds;
+
+    if (self.selectionType == SelectionTypeMiddle) {
+        
+        self.selectionLayer.path = [UIBezierPath bezierPathWithRect:self.selectionLayer.bounds].CGPath;
+        
+    } else if (self.selectionType == SelectionTypeLeftBorder) {
+        
+        self.selectionLayer.path = [UIBezierPath bezierPathWithRoundedRect:self.selectionLayer.bounds byRoundingCorners:UIRectCornerTopLeft|UIRectCornerBottomLeft cornerRadii:CGSizeMake(self.selectionLayer.fs_width/2, self.selectionLayer.fs_width/2)].CGPath;
+
+    } else if (self.selectionType == SelectionTypeRightBorder) {
+        
+        self.selectionLayer.path = [UIBezierPath bezierPathWithRoundedRect:self.selectionLayer.bounds byRoundingCorners:UIRectCornerTopRight|UIRectCornerBottomRight cornerRadii:CGSizeMake(self.selectionLayer.fs_width/2, self.selectionLayer.fs_width/2)].CGPath;
+        
+    } else if (self.selectionType == SelectionTypeSingle) {
+        
+        CGFloat diameter = MIN(self.selectionLayer.fs_height, self.selectionLayer.fs_width);
+        self.selectionLayer.path = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(self.contentView.fs_width/2-diameter/2, self.contentView.fs_height/2-diameter/2, diameter, diameter)].CGPath;
+        
+    }
+
+}
+
+- (void)configureAppearance
+{
+    [super configureAppearance];
+    // Override the build-in appearance configuration
+    if (self.isPlaceholder) {
+        self.titleLabel.textColor = [UIColor lightGrayColor];
+        self.eventIndicator.hidden = YES;
+    }
+}
+
+- (void)setSelectionType:(SelectionType)selectionType
+{
+    if (_selectionType != selectionType) {
+        _selectionType = selectionType;
+        [self setNeedsLayout];
+    }
+}
+
+@end

--- a/Hera/ViewControllers/Main Flow/Calendar/DIYCalendarCell.m
+++ b/Hera/ViewControllers/Main Flow/Calendar/DIYCalendarCell.m
@@ -11,8 +11,7 @@
 
 @implementation DIYCalendarCell
 
-- (instancetype)initWithFrame:(CGRect)frame
-{
+- (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
         UIImageView *circleImageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"circle"]];
@@ -20,7 +19,6 @@
         self.circleImageView = circleImageView;
         
         CAShapeLayer *selectionLayer = [[CAShapeLayer alloc] init];
-        selectionLayer.fillColor = [cc_calendar cellSelectedColor].CGColor;
         selectionLayer.actions = @{@"hidden":[NSNull null]};
         [self.contentView.layer insertSublayer:selectionLayer below:self.titleLabel.layer];
         self.selectionLayer = selectionLayer;
@@ -34,37 +32,22 @@
 }
 
 
-- (void)layoutSubviews
-{
+- (void)layoutSubviews {
     [super layoutSubviews];
     
     self.backgroundView.frame = CGRectInset(self.bounds, 1, 1);
     self.circleImageView.frame = self.backgroundView.frame;
     self.selectionLayer.frame = self.bounds;
 
-    if (self.selectionType == SelectionTypeMiddle) {
-        
-        self.selectionLayer.path = [UIBezierPath bezierPathWithRect:self.selectionLayer.bounds].CGPath;
-        
-    } else if (self.selectionType == SelectionTypeLeftBorder) {
-        
-        self.selectionLayer.path = [UIBezierPath bezierPathWithRoundedRect:self.selectionLayer.bounds byRoundingCorners:UIRectCornerTopLeft|UIRectCornerBottomLeft cornerRadii:CGSizeMake(self.selectionLayer.fs_width/2, self.selectionLayer.fs_width/2)].CGPath;
-
-    } else if (self.selectionType == SelectionTypeRightBorder) {
-        
-        self.selectionLayer.path = [UIBezierPath bezierPathWithRoundedRect:self.selectionLayer.bounds byRoundingCorners:UIRectCornerTopRight|UIRectCornerBottomRight cornerRadii:CGSizeMake(self.selectionLayer.fs_width/2, self.selectionLayer.fs_width/2)].CGPath;
-        
-    } else if (self.selectionType == SelectionTypeSingle) {
+    if (self.selectionType == SelectionTypeSingle) {
         
         CGFloat diameter = MIN(self.selectionLayer.fs_height, self.selectionLayer.fs_width);
         self.selectionLayer.path = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(self.contentView.fs_width/2-diameter/2, self.contentView.fs_height/2-diameter/2, diameter, diameter)].CGPath;
         
     }
-
 }
 
-- (void)configureAppearance
-{
+- (void)configureAppearance {
     [super configureAppearance];
     // Override the build-in appearance configuration
     if (self.isPlaceholder) {
@@ -73,12 +56,31 @@
     }
 }
 
-- (void)setSelectionType:(SelectionType)selectionType
-{
+- (void)setSelectionType:(SelectionType)selectionType {
     if (_selectionType != selectionType) {
         _selectionType = selectionType;
         [self setNeedsLayout];
     }
+}
+
+- (void)setEventProbability:(CGFloat)probability fillColor:(UIColor*)color {
+    
+    self.selectionLayer.fillColor = color.CGColor;
+
+    CGFloat indicatorHeight = probability * self.selectionLayer.bounds.size.height / 2.0;
+    CGRect rect = CGRectMake(self.selectionLayer.bounds.origin.x,
+                             self.selectionLayer.bounds.size.height - indicatorHeight,
+                             self.selectionLayer.bounds.size.width,
+                             indicatorHeight);
+    self.selectionLayer.path = [UIBezierPath bezierPathWithRect:rect].CGPath;
+}
+
+- (void)setPeriodProbability:(CGFloat)probability {
+    [self setEventProbability:probability fillColor:[cc_calendar periodIndicatorColor]];
+}
+
+- (void)setOvulationProbability:(CGFloat)probability {
+    [self setEventProbability:probability fillColor:[cc_calendar ovulationIndicatorColor]];
 }
 
 @end

--- a/Hera/ViewControllers/Main Flow/Calendar/cc_calendar.h
+++ b/Hera/ViewControllers/Main Flow/Calendar/cc_calendar.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 +(UIColor*)textDefaultColor;
 +(UIColor*)cellTodayBgColor;
 +(UIColor*)cellSelectedColor;
++(UIColor*)periodIndicatorColor;
++(UIColor*)ovulationIndicatorColor;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Hera/ViewControllers/Main Flow/Calendar/cc_calendar.m
+++ b/Hera/ViewControllers/Main Flow/Calendar/cc_calendar.m
@@ -34,4 +34,19 @@
 +(UIColor*)cellTodayBgColor {
     return [UIColor yellowColor];
 }
+
++(UIColor*)periodIndicatorColor {
+    return [UIColor colorWithRed:255./255.
+                           green:114./255.
+                           blue:118./255.
+                           alpha:1.];
+}
+
++(UIColor*)ovulationIndicatorColor {
+    return [UIColor colorWithRed:173./255.
+                           green:216./255.
+                           blue:230./255.
+                           alpha:1.];
+}
+
 @end

--- a/Hera/ViewControllers/Main Flow/Calendar/get_predictions.h
+++ b/Hera/ViewControllers/Main Flow/Calendar/get_predictions.h
@@ -1,0 +1,24 @@
+//
+//  get_predictions.h
+//  Hera
+//
+//  Created by Andreas Lordos on 7/25/22.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface get_predictions : NSObject
+@property (nonatomic) int cycleLength;
+@property (weak, nonatomic) NSDate* cycleStartDate;
+@property int periodDuration;
+@property int ovulationDuration;
+@property int ovulationStart;
+- (NSDate *)getDate:(int)year monthOffset:(int)month dayOffset:(int)day date:(NSDate *)date;
+- (NSMutableDictionary *)getPeriod;
+- (NSMutableDictionary *)getOvulation;
+@property NSCalendar *gregorian;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Hera/ViewControllers/Main Flow/Calendar/get_predictions.m
+++ b/Hera/ViewControllers/Main Flow/Calendar/get_predictions.m
@@ -1,0 +1,67 @@
+//
+//  get_predictions.m
+//  Hera
+//
+//  Created by Andreas Lordos on 7/25/22.
+//
+
+#import "get_predictions.h"
+
+@implementation get_predictions
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        [self setDefaults];
+    }
+    return self;
+}
+
+- (NSDate *)getDate:(int)year monthOffset:(int)month dayOffset:(int)day date:(NSDate *)date {
+    NSDateComponents *offsetComponents = [[NSDateComponents alloc] init];
+    [offsetComponents setYear:year];
+    [offsetComponents setMonth:month];
+    [offsetComponents setDay:day];
+    return [self.gregorian dateByAddingComponents:offsetComponents toDate:date options:0];
+}
+
+- (void)setDefaults {
+    self.gregorian = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+    self.cycleStartDate = [self getDate:0 monthOffset:-11 dayOffset:0 date:[[NSDate alloc] init]];
+    self.ovulationStart = 14;
+    self.ovulationDuration = 4;
+    self.periodDuration = 5;
+    self.cycleLength = 28;
+}
+
+- (NSString*)formatDate:(NSDate *)date {
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd"];
+    return [dateFormatter stringFromDate:date];
+}
+
+- (NSDictionary*)getOvulation {
+    return [self getEventWithDuration:self.ovulationDuration eventStart:14];
+}
+
+- (NSDictionary*)getPeriod {
+    return [self getEventWithDuration:self.periodDuration eventStart:0];
+
+}
+
+-(NSDictionary*)getEventWithDuration:(int)eventDuration eventStart:(int)eventStart {
+    NSDate *nextStartDate = self.cycleStartDate;
+    NSDate *firstDay = [self getDate:0 monthOffset:0 dayOffset:eventStart date:nextStartDate]; // start of event
+    NSMutableDictionary *returnDict = [[NSMutableDictionary alloc] initWithCapacity:100];
+    for (int i = 0; i < 20; i++) {
+        for (int j = 0; j < eventDuration; j++) {
+            float probability = 1-abs((j-((eventDuration-1)/2)))/((float)eventDuration);
+            [returnDict setObject:[NSNumber numberWithFloat:probability] forKey:[self formatDate:[self getDate:0 monthOffset:0 dayOffset:j date:firstDay]]];
+        }
+        firstDay = [self getDate:0 monthOffset:0 dayOffset:self.cycleLength date:firstDay];
+    }
+    return returnDict;
+}
+
+@end

--- a/Hera/ViewControllers/Main Flow/Cycle/CycleViewController.swift
+++ b/Hera/ViewControllers/Main Flow/Cycle/CycleViewController.swift
@@ -28,9 +28,9 @@ class CycleViewController: UIViewController, MSCircularSliderProtocol, MSCircula
     var valueBetweenLabels = 0.0 // initialized to 0
     
     override func viewDidLoad() {
+        determineCycle()
         super.viewDidLoad()
         self.slider.delegate = self;
-        determineCycle()
         createSlider()
         updateDayShown()
         // Do any additional setup after loading the view.
@@ -181,7 +181,5 @@ class CycleViewController: UIViewController, MSCircularSliderProtocol, MSCircula
             snapToClosestDay(value)
             valueToCurrentDay(self.slider.currentValue)
         }
-        print(value)
     }
-
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/29073065/180879522-5de18d32-6d7c-4147-b83f-7d65cba12b3c.mov

# Diff Summary

## Context / Problems / Issues

While the user can look at where they are in their current cycle in the "Cycle" tab, we wanted to add a way to look ahead (and behind) on past/future menstrual cycles, at a glance.

## This Diff / Solutions
This diff provides infrastructure needed to color calendar cells using CAShapeLayers in ``DIYCalendarCell.m``. Cells are colored for two reasons: to indicate predicted ovulation / bleeding. Cells are not only colored to show the event that may occur, but also the % cover of the colored layer is proportional to either predicted fertility or predicted bleeding. In the example above the calendar is using "dummy data" from ``get_predictions.m``

## Next Steps
Add a key, make cells tappable